### PR TITLE
Add optional chaining to user object’s properties

### DIFF
--- a/frontend/src/Pages/Educators/ProfileScreens/EducatorAccount/EducatorAccount.js
+++ b/frontend/src/Pages/Educators/ProfileScreens/EducatorAccount/EducatorAccount.js
@@ -22,7 +22,7 @@ const EducatorAccount = () => {
             <div className='my-auto'>
               <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userEmail}
+                placeholder={user?.userEmail}
               />
             </div>
           </div>
@@ -36,7 +36,7 @@ const EducatorAccount = () => {
             <div className='my-auto'>
               <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userPhoneNum}
+                placeholder={user?.userPhoneNum}
               />
             </div>
           </div>
@@ -50,7 +50,7 @@ const EducatorAccount = () => {
             <div className='my-auto'>
               <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userGender}
+                placeholder={user?.userGender}
               />
             </div>
           </div>
@@ -64,7 +64,7 @@ const EducatorAccount = () => {
             <div className='my-auto'>
               <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userCountry}
+                placeholder={user?.userCountry}
               />
             </div>
           </div>
@@ -78,7 +78,7 @@ const EducatorAccount = () => {
             <div className='my-auto'>
               <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userProvince}
+                placeholder={user?.userProvince}
               />
             </div>
           </div>
@@ -101,7 +101,7 @@ const EducatorAccount = () => {
               <input
                 className='form-input-noline ms-3 c-gray borRad-10'
                 type='text'
-                placeholder={user.name}
+                placeholder={user?.name}
               />
             </div>
           </div>
@@ -124,7 +124,7 @@ const EducatorAccount = () => {
             <div className='my-auto'>
               <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userPassword}
+                placeholder={user?.userPassword}
               />
             </div>
           </div>
@@ -135,7 +135,7 @@ const EducatorAccount = () => {
             <div className='my-auto'>
               <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userPassword}
+                placeholder={user?.userPassword}
               />
             </div>
           </div>
@@ -159,7 +159,7 @@ const EducatorAccount = () => {
               <input
                 className='form-input-noline ms-3 c-gray borRad-10'
                 type='text'
-                placeholder={user.email}
+                placeholder={user?.email}
               />
             </div>
           </div>

--- a/frontend/src/Pages/Educators/ProfileScreens/EducatorProfileHome/EducatorProfileHome.js
+++ b/frontend/src/Pages/Educators/ProfileScreens/EducatorProfileHome/EducatorProfileHome.js
@@ -19,8 +19,8 @@ const EducatorProfileHome = ({ courses }) => {
 					/>
 				</div>
 				<div className="col-md-8 mt-3 mt-sm-5">
-					<p className="fs-22 fw-600">{user.name}</p>
-					<p className="fs-16">{user.accountType}</p>
+					<p className="fs-22 fw-600">{user?.name}</p>
+					<p className="fs-16">{user?.accountType}</p>
 					<textarea
 						className="form-control mt-3"
 						rows={4}

--- a/frontend/src/Pages/Learners/ProfileScreens/Profile-Account/ProfileAccount.js
+++ b/frontend/src/Pages/Learners/ProfileScreens/Profile-Account/ProfileAccount.js
@@ -19,13 +19,13 @@ const ProfileAccount = () => {
 					/>
 				</div>
 				<div className="col-sm-8 mt-3 mt-sm-5">
-					<p className="fs-22 fw-600">{user.userFullName}</p>
+					<p className="fs-22 fw-600">{user?.userFullName}</p>
 					<p className="fs-16">Student/Learner</p>
 					<div className="row mt-4">
 						<div className="col-sm-6">
 							<p className="fs-14">
 								<span className="fw-600">Email: </span>
-								{user.email}
+								{user?.email}
 							</p>
 							<p className="fs-14">
 								<span className="fw-600">Password: </span>
@@ -33,21 +33,21 @@ const ProfileAccount = () => {
 							</p>
 							<p className="fs-14">
 								<span className="fw-600">Phone Number: </span>
-								{user.userPhoneNum}
+								{user?.userPhoneNum}
 							</p>
 						</div>
 						<div className="col-sm-6">
 							<p className="fs-14">
 								<span className="fw-600">Country: </span>
-								{user.country}
+								{user?.country}
 							</p>
 							<p className="fs-14">
 								<span className="fw-600">Province: </span>
-								{user.stateProvince}
+								{user?.stateProvince}
 							</p>
 							<p className="fs-14">
 								<span className="fw-600">City: </span>
-								{user.userCity}
+								{user?.userCity}
 							</p>
 						</div>
 					</div>
@@ -72,7 +72,7 @@ const ProfileAccount = () => {
 						<div className="my-auto">
 							<input
 								className="form-input-noline ms-3 c-gray borRad-10"
-								placeholder={user.userEmail}
+								placeholder={user?.userEmail}
 							/>
 						</div>
 					</div>
@@ -86,7 +86,7 @@ const ProfileAccount = () => {
 						<div className="my-auto">
 							<input
 								className="form-input-noline ms-3 c-gray borRad-10"
-								placeholder={user.userPhoneNum}
+								placeholder={user?.userPhoneNum}
 							/>
 						</div>
 					</div>
@@ -100,7 +100,7 @@ const ProfileAccount = () => {
 						<div className="my-auto">
 							<input
 								className="form-input-noline ms-3 c-gray borRad-10"
-								placeholder={user.userGender}
+								placeholder={user?.userGender}
 							/>
 						</div>
 					</div>
@@ -114,7 +114,7 @@ const ProfileAccount = () => {
 						<div className="my-auto">
 							<input
 								className="form-input-noline ms-3 c-gray borRad-10"
-								placeholder={user.userCountry}
+								placeholder={user?.userCountry}
 							/>
 						</div>
 					</div>
@@ -128,7 +128,7 @@ const ProfileAccount = () => {
 						<div className="my-auto">
 							<input
 								className="form-input-noline ms-3 c-gray borRad-10"
-								placeholder={user.userProvince}
+								placeholder={user?.userProvince}
 							/>
 						</div>
 					</div>
@@ -150,7 +150,7 @@ const ProfileAccount = () => {
 						<div className="my-auto">
 							<input
 								className="form-input-noline ms-3 c-gray borRad-10"
-								placeholder={user.userPassword}
+								placeholder={user?.userPassword}
 							/>
 						</div>
 					</div>
@@ -168,7 +168,7 @@ const ProfileAccount = () => {
 						<div className="my-auto ms-auto w-50">
 							{/* <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userEmail}
+                placeholder={user?.userEmail}
               /> */}
 							<select className="form-select language-selection bor-blue c-darkBlue">
 								<option selected value="english">
@@ -194,7 +194,7 @@ const ProfileAccount = () => {
 						<div className="my-auto ms-auto">
 							{/* <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userEmail}
+                placeholder={user?.userEmail}
               /> */}
 							<div className="form-check form-switch">
 								<input
@@ -215,7 +215,7 @@ const ProfileAccount = () => {
 						<div className="my-auto ms-auto">
 							{/* <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userEmail}
+                placeholder={user?.userEmail}
               /> */}
 							<select className="form-select language-selection bor-blue c-darkBlue">
 								<option selected value="10:00pm">
@@ -237,7 +237,7 @@ const ProfileAccount = () => {
 						<div className="my-auto ms-auto">
 							{/* <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userEmail}
+                placeholder={user?.userEmail}
               /> */}
 							<div className="form-check form-switch">
 								<input
@@ -258,7 +258,7 @@ const ProfileAccount = () => {
 						<div className="my-auto ms-auto">
 							{/* <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userEmail}
+                placeholder={user?.userEmail}
               /> */}
 							<div className="form-check form-switch">
 								<input
@@ -279,7 +279,7 @@ const ProfileAccount = () => {
 						<div className="my-auto ms-auto">
 							{/* <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userEmail}
+                placeholder={user?.userEmail}
               /> */}
 							<div className="form-check form-switch">
 								<input

--- a/frontend/src/Pages/Learners/ProfileScreens/Profile-Home/ProfileHome.js
+++ b/frontend/src/Pages/Learners/ProfileScreens/Profile-Home/ProfileHome.js
@@ -26,15 +26,15 @@ const ProfileHome = ({ courses }) => {
 				<div className="col-md-4">
 					<p className="fs-22 fw-600">Profile (Public)</p>
 					<img
-						src={`/uploads/${user.profilePic}`}
+						src={`/uploads/${user?.profilePic}`}
 						alt="ProfilePic"
 						width={200}
 						height={200}
 					/>
 				</div>
 				<div className="col-md-8 mt-3 mt-sm-5">
-					<p className="fs-22 fw-600">{user.name}</p>
-					<p className="fs-16">{user.accountType}</p>
+					<p className="fs-22 fw-600">{user?.name}</p>
+					<p className="fs-16">{user?.accountType}</p>
 					<textarea
 						className="form-control mt-3"
 						rows={4}

--- a/frontend/src/Pages/Learners/ProfileScreens/Profile-Privacy/ProfilePrivacy.js
+++ b/frontend/src/Pages/Learners/ProfileScreens/Profile-Privacy/ProfilePrivacy.js
@@ -21,7 +21,7 @@ const ProfilePrivacy = () => {
             <div className='my-auto'>
               <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userEmail}
+                placeholder={user?.userEmail}
               />
             </div>
           </div>
@@ -35,7 +35,7 @@ const ProfilePrivacy = () => {
             <div className='my-auto'>
               <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userEmail}
+                placeholder={user?.userEmail}
               />
             </div>
           </div>
@@ -49,7 +49,7 @@ const ProfilePrivacy = () => {
             <div className='my-auto'>
               <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userEmail}
+                placeholder={user?.userEmail}
               />
             </div>
           </div>
@@ -71,7 +71,7 @@ const ProfilePrivacy = () => {
             <div className='my-auto'>
               <input
                 className='form-input-noline ms-3 c-gray borRad-10'
-                placeholder={user.userEmail}
+                placeholder={user?.userEmail}
               />
             </div>
           </div>

--- a/frontend/src/Pages/Profile/Profile.js
+++ b/frontend/src/Pages/Profile/Profile.js
@@ -141,7 +141,7 @@ const Profile = () => {
         <div className='col-3 border-end bor-lightGray py-5 px-md-3 px-lg-5'>
           <SideDashboard
             sideDashboardOptions={
-              user.accountType === 'Learner'
+              user?.accountType === 'Learner'
                 ? learnerSideDashboardOptions
                 : educatorSideDashboardOptions
             }


### PR DESCRIPTION
I added [optional chaining (?.)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
) to user object’s properties.
Because profile related pages are failing to obtain user info from `window.sessionStorage`.

You can check it out with `console.log("user:", user)`

```
const user = JSON.parse(window.sessionStorage.getItem("user"));
console.log("user:", user)
```

On a console tab of Chome developer tools

```
user: null
```

It has still a problem that doesn't have user info, but it can avoid the website from crashing.

To solve it completely and get user from backend, I think it needs those following works

- API communication between frontend and backend to get user
- Cache user info locally or an appropriate somewhere
  - name, email, etc to get user from MongoDB
- user authentication 
  - check users have expired(invalid) jwt token
